### PR TITLE
Feat: (#25) Codef API 요청할 때 '-' 제거

### DIFF
--- a/src/main/java/com/seoulmilk/be/auth/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/seoulmilk/be/auth/exception/errorcode/AuthErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    EXIST_EMPLOYEE_ID(HttpStatus.ALREADY_REPORTED, "The employee ID already exists."),
-    EXIST_EMAIL(HttpStatus.ALREADY_REPORTED, "The email already exists."),
+    EXIST_EMPLOYEE_ID(HttpStatus.CONFLICT, "The employee ID already exists."),
+    EXIST_EMAIL(HttpStatus.CONFLICT, "The email already exists."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/seoulmilk/be/auth/presentation/api/AuthApi.java
+++ b/src/main/java/com/seoulmilk/be/auth/presentation/api/AuthApi.java
@@ -22,12 +22,8 @@ public interface AuthApi {
                     description = "회원가입이 성공적으로 완료되었습니다."
             ),
             @ApiResponse(
-                    responseCode = "208",
-                    description = "The employee ID already exists."
-            ),
-            @ApiResponse(
-                    responseCode = "208",
-                    description = "The email already exists."
+                    responseCode = "409",
+                    description = "회원 정보가 중복됩니다."
             )
     })
     SuccessResponse<String> signUpOffice(OfficeSignUpRequest request);
@@ -42,12 +38,8 @@ public interface AuthApi {
                     description = "회원가입이 성공적으로 완료되었습니다."
             ),
             @ApiResponse(
-                    responseCode = "208",
-                    description = "The employee ID already exists."
-            ),
-            @ApiResponse(
-                    responseCode = "208",
-                    description = "The email already exists."
+                    responseCode = "409",
+                    description = "회원 정보가 중복됩니다."
             )
     })
     SuccessResponse<String> signUpBranch(BranchSignUpRequest request);

--- a/src/main/java/com/seoulmilk/be/taxvalidation/application/TaxValidationService.java
+++ b/src/main/java/com/seoulmilk/be/taxvalidation/application/TaxValidationService.java
@@ -9,7 +9,7 @@ import com.seoulmilk.be.tax.persistence.NtsTaxRepository;
 import com.seoulmilk.be.taxvalidation.dto.request.CodefRequest;
 import com.seoulmilk.be.taxvalidation.dto.response.InvoiceVerificationResponse;
 import com.seoulmilk.be.taxvalidation.exception.TaxValidationException;
-import com.seoulmilk.be.taxvalidation.infrastructure.auth.EasyCodefProvider;
+import com.seoulmilk.be.taxvalidation.infrastructure.codef.EasyCodefProvider;
 import com.seoulmilk.be.taxvalidation.infrastructure.request.EasyCodefRequestFactory;
 import com.seoulmilk.be.user.domain.User;
 import io.codef.api.EasyCodef;
@@ -89,7 +89,8 @@ public class TaxValidationService {
 
     private String requestCodef(CodefRequest request) {
         EasyCodef codef = easyCodefProvider.getEasyCodef();
-        HashMap<String, Object> body = easyCodefRequestFactory.createValidationRequest(request.user(), request.ntsTax(), request.loginTypeLevel());
+        HashMap<String, Object> body = easyCodefRequestFactory.createValidationRequest(
+                request.user(), request.ntsTax(), request.loginTypeLevel());
 
         if (request.isTwoWay()) {
             body.putAll(Map.of(SIMPLE_AUTH.getParamName(), NORMAL.getValue(), IS_2_WAY.getParamName(), true));

--- a/src/main/java/com/seoulmilk/be/taxvalidation/infrastructure/codef/EasyCodefProvider.java
+++ b/src/main/java/com/seoulmilk/be/taxvalidation/infrastructure/codef/EasyCodefProvider.java
@@ -1,4 +1,4 @@
-package com.seoulmilk.be.taxvalidation.infrastructure.auth;
+package com.seoulmilk.be.taxvalidation.infrastructure.codef;
 
 import io.codef.api.EasyCodef;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/seoulmilk/be/taxvalidation/infrastructure/request/EasyCodefRequestFactory.java
+++ b/src/main/java/com/seoulmilk/be/taxvalidation/infrastructure/request/EasyCodefRequestFactory.java
@@ -47,12 +47,15 @@ public class EasyCodefRequestFactory {
 
     private HashMap<String, Object> createNtsTaxRequest(NtsTax ntsTax) {
         HashMap<String, Object> request = new HashMap<>();
-        request.put(SUPPLIER_REG_NUMBER.getParamName(), ntsTax.getSuId().replace(BAR, ""));
-        request.put(CONTRACTOR_REG_NUMBER.getParamName(), ntsTax.getIpId().replace(BAR, ""));
-        request.put(APPROVAL_NO.getParamName(), ntsTax.getIssueId());
+        request.put(SUPPLIER_REG_NUMBER.getParamName(), getRemovedBarStr(ntsTax.getSuId()));
+        request.put(CONTRACTOR_REG_NUMBER.getParamName(), getRemovedBarStr(ntsTax.getIpId()));
+        request.put(APPROVAL_NO.getParamName(), getRemovedBarStr(ntsTax.getIssueId()));
         request.put(REPORTING_DATE.getParamName(), ntsTax.getIssueDate());
         request.put(SUPPLY_VALUE.getParamName(), ntsTax.getChargeTotal().toString());
         return request;
     }
 
+    private String getRemovedBarStr(String barStr) {
+        return barStr.replace(BAR, "");
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #25 

## 📝작업 내용
> Codef API 요청할 때 파라미터 값의 '-' 를 제거해서 요청 보냅니다.
> swagger 설명 오류 설명 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?