### PR TITLE
Feat: (#21) 대리점 세금계산서 조회

### DIFF
--- a/src/main/java/com/seoulmilk/be/global/dto/SuccessCode.java
+++ b/src/main/java/com/seoulmilk/be/global/dto/SuccessCode.java
@@ -13,6 +13,8 @@ public enum SuccessCode {
     LIST_BEFRORE_VALIDATE_TAX_SUCCESS(200, "세금계산서 검증 전 리스트 조회가 성공적으로 완료되었습니다."),
     OFFICE_TAX_FILTER_SUCCESS(200, "본사 세금계산서 필터링이 성공적으로 완료되었습니다."),
     OFFICE_TAX_DETAIL_SUCCESS(200, "본사 세금계산서 상세 조회가 성공적으로 완료되었습니다."),
+    BRANCH_TAX_FILTER_SUCCESS(200, "대리점 세금계산서 필터링 조회가 성공적으로 완료되었습니다."),
+    BRANCH_TAX_DETAIL_SUCCESS(200, "대리점 세금계산서 상세 조회가 성공적으로 완료되었습니다."),
     VALIDATE_TAX_INVOICE_SUCCESS(200, "세금계산서 검증이 성공적으로 요청되었습니다."),
     ;
 

--- a/src/main/java/com/seoulmilk/be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/seoulmilk/be/global/exception/GlobalExceptionHandler.java
@@ -1,9 +1,13 @@
 package com.seoulmilk.be.global.exception;
 
+import com.seoulmilk.be.auth.exception.ExistUserException;
 import com.seoulmilk.be.global.exception.errorcode.ErrorCode;
 import com.seoulmilk.be.global.exception.errorcode.GlobalErrorCode;
+import com.seoulmilk.be.global.exception.errorcode.UserNotFoundException;
 import com.seoulmilk.be.global.exception.response.ErrorResponse;
+import com.seoulmilk.be.taxvalidation.exception.TaxValidationException;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.xml.bind.ValidationException;
 import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +39,24 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(FileConvertFailException.class)
     public ResponseEntity<Object> handleFileConvertFail(FileConvertFailException e, HttpServletRequest request) {
+        log.info(String.valueOf(e.getErrorCode()), request);
+        return handleExceptionInternal(e.getErrorCode());
+    }
+
+    @ExceptionHandler(ExistUserException.class)
+    public ResponseEntity<Object> handleExistUserException(ExistUserException e, HttpServletRequest request) {
+        log.info(String.valueOf(e.getErrorCode()), request);
+        return handleExceptionInternal(e.getErrorCode());
+    }
+
+    @ExceptionHandler(TaxValidationException.class)
+    public ResponseEntity<Object> handleTaxValidationException(TaxValidationException e, HttpServletRequest request) {
+        log.info(String.valueOf(e.getErrorCode()), request);
+        return handleExceptionInternal(e.getErrorCode());
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<Object> handleUserNotFoundException(UserNotFoundException e, HttpServletRequest request) {
         log.info(String.valueOf(e.getErrorCode()), request);
         return handleExceptionInternal(e.getErrorCode());
     }

--- a/src/main/java/com/seoulmilk/be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/seoulmilk/be/global/exception/GlobalExceptionHandler.java
@@ -5,9 +5,9 @@ import com.seoulmilk.be.global.exception.errorcode.ErrorCode;
 import com.seoulmilk.be.global.exception.errorcode.GlobalErrorCode;
 import com.seoulmilk.be.global.exception.errorcode.UserNotFoundException;
 import com.seoulmilk.be.global.exception.response.ErrorResponse;
+import com.seoulmilk.be.tax.exception.UnauthorizedTaxUserException;
 import com.seoulmilk.be.taxvalidation.exception.TaxValidationException;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.xml.bind.ValidationException;
 import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +57,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<Object> handleUserNotFoundException(UserNotFoundException e, HttpServletRequest request) {
+        log.info(String.valueOf(e.getErrorCode()), request);
+        return handleExceptionInternal(e.getErrorCode());
+    }
+
+    @ExceptionHandler(UnauthorizedTaxUserException.class)
+    public ResponseEntity<Object> handleUnauthorizedTaxUserException(UnauthorizedTaxUserException e, HttpServletRequest request) {
         log.info(String.valueOf(e.getErrorCode()), request);
         return handleExceptionInternal(e.getErrorCode());
     }

--- a/src/main/java/com/seoulmilk/be/tax/application/BranchTaxService.java
+++ b/src/main/java/com/seoulmilk/be/tax/application/BranchTaxService.java
@@ -1,9 +1,11 @@
 package com.seoulmilk.be.tax.application;
 
+import com.seoulmilk.be.auth.service.AuthService;
 import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponse;
 import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponseList;
 import com.seoulmilk.be.tax.persistence.NtsTaxRepository;
 import com.seoulmilk.be.taxvalidation.dto.request.BranchTaxFilterRequest;
+import com.seoulmilk.be.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -17,11 +19,13 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BranchTaxService {
+    private final AuthService authService;
     private final NtsTaxRepository ntsTaxRepository;
 
     public BranchTaxFilterResponseList findBranchTaxByFilters(BranchTaxFilterRequest request) {
+        User user = authService.getLoginUser();
         Pageable pageable = PageRequest.of(request.getPage() - 1, request.getSize());
-        List<BranchTaxFilterResponse> filteredTax = ntsTaxRepository.findBranchTaxByFilters(request, pageable);
+        List<BranchTaxFilterResponse> filteredTax = ntsTaxRepository.findBranchTaxByFiltersAndUser(request, user, pageable);
         return BranchTaxFilterResponseList.of(filteredTax, filteredTax.size());
     }
 }

--- a/src/main/java/com/seoulmilk/be/tax/application/BranchTaxService.java
+++ b/src/main/java/com/seoulmilk/be/tax/application/BranchTaxService.java
@@ -36,14 +36,18 @@ public class BranchTaxService {
         return BranchTaxFilterResponseList.of(filteredTax, filteredTax.size());
     }
 
-    public BranchTaxDetailResponse findOfficeTaxDetail(Long taxId) {
+    public BranchTaxDetailResponse findBranchTaxDetail(Long taxId) {
         User user = authService.getLoginUser();
         NtsTax ntsTax = ntsTaxRepository.findById(taxId)
                 .orElseThrow(() -> new NtsTaxNotFoundException(NTS_TAX_NOT_FOUND));
-        if (!ntsTax.getSuId().equals(user.getEmployeeId())) {
+        if (!getRemovedBar(ntsTax.getSuId()).equals(getRemovedBar(user.getEmployeeId()))) {
             throw new UnauthorizedTaxUserException(UNAUTHORIZED_TAX_USER);
         }
 
         return BranchTaxDetailResponse.of(ntsTax);
+    }
+
+    private String getRemovedBar(String barStr) {
+        return barStr.replace("-", "");
     }
 }

--- a/src/main/java/com/seoulmilk/be/tax/application/BranchTaxService.java
+++ b/src/main/java/com/seoulmilk/be/tax/application/BranchTaxService.java
@@ -1,0 +1,27 @@
+package com.seoulmilk.be.tax.application;
+
+import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponse;
+import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponseList;
+import com.seoulmilk.be.tax.persistence.NtsTaxRepository;
+import com.seoulmilk.be.taxvalidation.dto.request.BranchTaxFilterRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BranchTaxService {
+    private final NtsTaxRepository ntsTaxRepository;
+
+    public BranchTaxFilterResponseList findBranchTaxByFilters(BranchTaxFilterRequest request) {
+        Pageable pageable = PageRequest.of(request.getPage() - 1, request.getSize());
+        List<BranchTaxFilterResponse> filteredTax = ntsTaxRepository.findBranchTaxByFilters(request, pageable);
+        return BranchTaxFilterResponseList.of(filteredTax, filteredTax.size());
+    }
+}

--- a/src/main/java/com/seoulmilk/be/tax/application/BranchTaxService.java
+++ b/src/main/java/com/seoulmilk/be/tax/application/BranchTaxService.java
@@ -1,8 +1,12 @@
 package com.seoulmilk.be.tax.application;
 
 import com.seoulmilk.be.auth.service.AuthService;
+import com.seoulmilk.be.tax.domain.NtsTax;
+import com.seoulmilk.be.tax.dto.response.BranchTaxDetailResponse;
 import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponse;
 import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponseList;
+import com.seoulmilk.be.tax.exception.NtsTaxNotFoundException;
+import com.seoulmilk.be.tax.exception.UnauthorizedTaxUserException;
 import com.seoulmilk.be.tax.persistence.NtsTaxRepository;
 import com.seoulmilk.be.taxvalidation.dto.request.BranchTaxFilterRequest;
 import com.seoulmilk.be.user.domain.User;
@@ -13,6 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.seoulmilk.be.tax.exception.errorcode.NtsTaxErrorCode.NTS_TAX_NOT_FOUND;
+import static com.seoulmilk.be.tax.exception.errorcode.NtsTaxErrorCode.UNAUTHORIZED_TAX_USER;
 
 
 @Service
@@ -27,5 +34,16 @@ public class BranchTaxService {
         Pageable pageable = PageRequest.of(request.getPage() - 1, request.getSize());
         List<BranchTaxFilterResponse> filteredTax = ntsTaxRepository.findBranchTaxByFiltersAndUser(request, user, pageable);
         return BranchTaxFilterResponseList.of(filteredTax, filteredTax.size());
+    }
+
+    public BranchTaxDetailResponse findOfficeTaxDetail(Long taxId) {
+        User user = authService.getLoginUser();
+        NtsTax ntsTax = ntsTaxRepository.findById(taxId)
+                .orElseThrow(() -> new NtsTaxNotFoundException(NTS_TAX_NOT_FOUND));
+        if (!ntsTax.getSuId().equals(user.getEmployeeId())) {
+            throw new UnauthorizedTaxUserException(UNAUTHORIZED_TAX_USER);
+        }
+
+        return BranchTaxDetailResponse.of(ntsTax);
     }
 }

--- a/src/main/java/com/seoulmilk/be/tax/dto/response/BranchTaxDetailResponse.java
+++ b/src/main/java/com/seoulmilk/be/tax/dto/response/BranchTaxDetailResponse.java
@@ -1,0 +1,41 @@
+package com.seoulmilk.be.tax.dto.response;
+
+import com.seoulmilk.be.tax.domain.NtsTax;
+import com.seoulmilk.be.tax.domain.type.PayStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record BranchTaxDetailResponse(
+        Long id,
+        String imageUrl,
+
+        @Schema(description = "승인 번호")
+        String issueId,
+
+        @Schema(description = "생성 일자")
+        LocalDateTime createdDateTime,
+
+        @Schema(description = "금액")
+        Long grandTotal,
+
+        @Schema(description = "지급 상태")
+        PayStatus payStatus,
+
+        @Schema(description = "지급 날짜")
+        String payDate
+) {
+    public static BranchTaxDetailResponse of(NtsTax ntsTax) {
+        return BranchTaxDetailResponse.builder()
+                .id(ntsTax.getId())
+                .imageUrl(ntsTax.getImageUrl())
+                .issueId(ntsTax.getIssueId())
+                .createdDateTime(ntsTax.getCreatedDateTime())
+                .grandTotal(ntsTax.getGrandTotal())
+                .payStatus(ntsTax.getPayStatus())
+                .payDate(ntsTax.getPayDate())
+                .build();
+    }
+}

--- a/src/main/java/com/seoulmilk/be/tax/dto/response/BranchTaxFilterResponse.java
+++ b/src/main/java/com/seoulmilk/be/tax/dto/response/BranchTaxFilterResponse.java
@@ -1,0 +1,18 @@
+package com.seoulmilk.be.tax.dto.response;
+
+import com.seoulmilk.be.tax.domain.type.PayStatus;
+import com.seoulmilk.be.tax.domain.type.ResultType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record BranchTaxFilterResponse(
+        Long id,
+        String issueId,
+        ResultType isNormal,
+        PayStatus payStatus,
+        LocalDateTime createdDateTime
+) {
+
+}

--- a/src/main/java/com/seoulmilk/be/tax/dto/response/BranchTaxFilterResponseList.java
+++ b/src/main/java/com/seoulmilk/be/tax/dto/response/BranchTaxFilterResponseList.java
@@ -1,0 +1,19 @@
+package com.seoulmilk.be.tax.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record BranchTaxFilterResponseList(
+        List<BranchTaxFilterResponse> branchTaxFilterResponses,
+        int totalPageSize
+) {
+    public static BranchTaxFilterResponseList of(
+            List<BranchTaxFilterResponse> branchTaxFilterResponses, int totalPageSize) {
+        return BranchTaxFilterResponseList.builder()
+                .branchTaxFilterResponses(branchTaxFilterResponses)
+                .totalPageSize(totalPageSize)
+                .build();
+    }
+}

--- a/src/main/java/com/seoulmilk/be/tax/exception/UnauthorizedTaxUserException.java
+++ b/src/main/java/com/seoulmilk/be/tax/exception/UnauthorizedTaxUserException.java
@@ -1,0 +1,11 @@
+package com.seoulmilk.be.tax.exception;
+
+import com.seoulmilk.be.global.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UnauthorizedTaxUserException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/seoulmilk/be/tax/exception/errorcode/NtsTaxErrorCode.java
+++ b/src/main/java/com/seoulmilk/be/tax/exception/errorcode/NtsTaxErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum NtsTaxErrorCode implements ErrorCode {
     NTS_TAX_NOT_FOUND(HttpStatus.NOT_FOUND, "No NTS tax found"),
+    UNAUTHORIZED_TAX_USER(HttpStatus.UNAUTHORIZED, "User is not authorized to access this tax detail.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/seoulmilk/be/tax/persistence/NtsTaxRepositoryCustom.java
+++ b/src/main/java/com/seoulmilk/be/tax/persistence/NtsTaxRepositoryCustom.java
@@ -1,6 +1,9 @@
 package com.seoulmilk.be.tax.persistence;
 
+import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponse;
 import com.seoulmilk.be.tax.dto.response.OfficeTaxFilterResponse;
+import com.seoulmilk.be.taxvalidation.dto.request.BranchTaxFilterRequest;
+import com.seoulmilk.be.user.domain.User;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
@@ -15,4 +18,6 @@ public interface NtsTaxRepositoryCustom {
                                                           String resultType,
                                                           String isValidated,
                                                           Pageable pageable);
+
+    List<BranchTaxFilterResponse> findBranchTaxByFiltersAndUser(BranchTaxFilterRequest filter, User user, Pageable pageable);
 }

--- a/src/main/java/com/seoulmilk/be/tax/persistence/NtsTaxRepositoryCustomImpl.java
+++ b/src/main/java/com/seoulmilk/be/tax/persistence/NtsTaxRepositoryCustomImpl.java
@@ -3,8 +3,12 @@ package com.seoulmilk.be.tax.persistence;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seoulmilk.be.tax.domain.type.PayStatus;
 import com.seoulmilk.be.tax.domain.type.ResultType;
+import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponse;
 import com.seoulmilk.be.tax.dto.response.OfficeTaxFilterResponse;
+import com.seoulmilk.be.taxvalidation.dto.request.BranchTaxFilterRequest;
+import com.seoulmilk.be.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -58,6 +62,29 @@ public class NtsTaxRepositoryCustomImpl implements NtsTaxRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public List<BranchTaxFilterResponse> findBranchTaxByFiltersAndUser(BranchTaxFilterRequest filter, User user, Pageable pageable) {
+        return jpaQueryFactory
+                .select(Projections.constructor(BranchTaxFilterResponse.class,
+                        ntsTax.id,
+                        ntsTax.issueId,
+                        ntsTax.isNormal,
+                        ntsTax.payStatus,
+                        ntsTax.createdDateTime
+                ))
+                .from(ntsTax)
+                .orderBy(ntsTax.id.desc())
+                .where(
+                        filterByPayStatus(filter.getPayStatus()),
+                        filterByResultType(filter.getResultType()),
+                        filterByYearAndMonth(filter.getStartDate(), filter.getEndDate()),
+                        ntsTax.user.eq(user)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
     private BooleanExpression filterByRegion(String region) {
         if (ObjectUtils.isEmpty(region)) {
             return null;
@@ -84,6 +111,13 @@ public class NtsTaxRepositoryCustomImpl implements NtsTaxRepositoryCustom {
         }
     }
 
+    private BooleanExpression filterByPayStatus(PayStatus payStatus) {
+        if (payStatus == null) {
+            return null;
+        }
+        return ntsTax.payStatus.eq(payStatus);
+    }
+
     private BooleanExpression filterByYearAndMonth(LocalDate startYearAndMonth, LocalDate endYearAndMonth) {
         if (ObjectUtils.isEmpty(startYearAndMonth) || ObjectUtils.isEmpty(endYearAndMonth)) {
             return null;
@@ -107,4 +141,5 @@ public class NtsTaxRepositoryCustomImpl implements NtsTaxRepositoryCustom {
             return ntsTax.isValidated.eq(isValidated);
         }
     }
+
 }

--- a/src/main/java/com/seoulmilk/be/tax/persistence/NtsTaxRepositoryCustomImpl.java
+++ b/src/main/java/com/seoulmilk/be/tax/persistence/NtsTaxRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package com.seoulmilk.be.tax.persistence;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.seoulmilk.be.tax.domain.type.PayStatus;
 import com.seoulmilk.be.tax.domain.type.ResultType;
@@ -78,7 +79,8 @@ public class NtsTaxRepositoryCustomImpl implements NtsTaxRepositoryCustom {
                         filterByPayStatus(filter.getPayStatus()),
                         filterByResultType(filter.getResultType()),
                         filterByYearAndMonth(filter.getStartDate(), filter.getEndDate()),
-                        ntsTax.user.eq(user)
+                        Expressions.stringTemplate("REPLACE({0}, '-', '')", ntsTax.suId)
+                                .eq(user.getEmployeeId().replace("-", ""))
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/seoulmilk/be/tax/persistence/init/NtsTaxDummy.java
+++ b/src/main/java/com/seoulmilk/be/tax/persistence/init/NtsTaxDummy.java
@@ -42,7 +42,7 @@ public class NtsTaxDummy implements ApplicationRunner {
                     .arap(Arap.AP)
                     .issueDt("2024-01-01")
                     .issueDate("20240101")
-                    .suId("444-33-22222")
+                    .suId("123-45-678")
                     .ipId("333-22-88855")
                     .chargeTotal(2752800L)
                     .taxTotal(0L)

--- a/src/main/java/com/seoulmilk/be/tax/persistence/init/NtsTaxDummy.java
+++ b/src/main/java/com/seoulmilk/be/tax/persistence/init/NtsTaxDummy.java
@@ -42,7 +42,7 @@ public class NtsTaxDummy implements ApplicationRunner {
                     .arap(Arap.AP)
                     .issueDt("2024-01-01")
                     .issueDate("20240101")
-                    .suId("123-45-678")
+                    .suId("444-33-22222")
                     .ipId("333-22-88855")
                     .chargeTotal(2752800L)
                     .taxTotal(0L)

--- a/src/main/java/com/seoulmilk/be/tax/presentation/BranchTaxController.java
+++ b/src/main/java/com/seoulmilk/be/tax/presentation/BranchTaxController.java
@@ -2,14 +2,17 @@ package com.seoulmilk.be.tax.presentation;
 
 import com.seoulmilk.be.global.dto.SuccessResponse;
 import com.seoulmilk.be.tax.application.BranchTaxService;
+import com.seoulmilk.be.tax.dto.response.BranchTaxDetailResponse;
 import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponseList;
+import com.seoulmilk.be.tax.dto.response.OfficeTaxDetailResponse;
 import com.seoulmilk.be.tax.presentation.api.BranchTaxApi;
 import com.seoulmilk.be.taxvalidation.dto.request.BranchTaxFilterRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.seoulmilk.be.global.dto.SuccessCode.BRANCH_TAX_FILTER_SUCCESS;
+import static com.seoulmilk.be.global.dto.SuccessCode.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -25,5 +28,16 @@ public class BranchTaxController implements BranchTaxApi {
     ) {
         return SuccessResponse.of(BRANCH_TAX_FILTER_SUCCESS,
                 branchTaxService.findBranchTaxByFilters(request));
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{taxId}")
+    @Override
+    public SuccessResponse<BranchTaxDetailResponse> findBranchTaxDetail(
+            @PathVariable Long taxId
+    ) {
+        BranchTaxDetailResponse response = branchTaxService.findOfficeTaxDetail(taxId);
+
+        return SuccessResponse.of(BRANCH_TAX_DETAIL_SUCCESS, response);
     }
 }

--- a/src/main/java/com/seoulmilk/be/tax/presentation/BranchTaxController.java
+++ b/src/main/java/com/seoulmilk/be/tax/presentation/BranchTaxController.java
@@ -1,0 +1,29 @@
+package com.seoulmilk.be.tax.presentation;
+
+import com.seoulmilk.be.global.dto.SuccessResponse;
+import com.seoulmilk.be.tax.application.BranchTaxService;
+import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponseList;
+import com.seoulmilk.be.tax.presentation.api.BranchTaxApi;
+import com.seoulmilk.be.taxvalidation.dto.request.BranchTaxFilterRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import static com.seoulmilk.be.global.dto.SuccessCode.BRANCH_TAX_FILTER_SUCCESS;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/tax-invoices/branch")
+public class BranchTaxController implements BranchTaxApi {
+    private final BranchTaxService branchTaxService;
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/filter")
+    @Override
+    public SuccessResponse<BranchTaxFilterResponseList> findBranchTaxByFilters(
+            @ModelAttribute BranchTaxFilterRequest request
+    ) {
+        return SuccessResponse.of(BRANCH_TAX_FILTER_SUCCESS,
+                branchTaxService.findBranchTaxByFilters(request));
+    }
+}

--- a/src/main/java/com/seoulmilk/be/tax/presentation/BranchTaxController.java
+++ b/src/main/java/com/seoulmilk/be/tax/presentation/BranchTaxController.java
@@ -36,7 +36,7 @@ public class BranchTaxController implements BranchTaxApi {
     public SuccessResponse<BranchTaxDetailResponse> findBranchTaxDetail(
             @PathVariable Long taxId
     ) {
-        BranchTaxDetailResponse response = branchTaxService.findOfficeTaxDetail(taxId);
+        BranchTaxDetailResponse response = branchTaxService.findBranchTaxDetail(taxId);
 
         return SuccessResponse.of(BRANCH_TAX_DETAIL_SUCCESS, response);
     }

--- a/src/main/java/com/seoulmilk/be/tax/presentation/api/BranchTaxApi.java
+++ b/src/main/java/com/seoulmilk/be/tax/presentation/api/BranchTaxApi.java
@@ -1,0 +1,31 @@
+package com.seoulmilk.be.tax.presentation.api;
+
+import com.seoulmilk.be.global.dto.SuccessResponse;
+import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponseList;
+import com.seoulmilk.be.taxvalidation.dto.request.BranchTaxFilterRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+
+@Tag(name = "Branch", description = "대리점 조회 API")
+public interface BranchTaxApi {
+
+    @Operation(
+            summary = "대리점 세금 계산서 필터링 조회",
+            description = "로그인한 대리점의 세금 계산서를 필터 조건에 맞춰 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "지점 세금 계산서가 필터 조건에 맞게 성공적으로 조회되었습니다."
+            )
+    })
+    SuccessResponse<BranchTaxFilterResponseList> findBranchTaxByFilters(
+            @Parameter(description = "대리점 세금 계산서 필터 조건")
+            @ModelAttribute BranchTaxFilterRequest request
+    );
+}

--- a/src/main/java/com/seoulmilk/be/tax/presentation/api/BranchTaxApi.java
+++ b/src/main/java/com/seoulmilk/be/tax/presentation/api/BranchTaxApi.java
@@ -1,6 +1,7 @@
 package com.seoulmilk.be.tax.presentation.api;
 
 import com.seoulmilk.be.global.dto.SuccessResponse;
+import com.seoulmilk.be.tax.dto.response.BranchTaxDetailResponse;
 import com.seoulmilk.be.tax.dto.response.BranchTaxFilterResponseList;
 import com.seoulmilk.be.taxvalidation.dto.request.BranchTaxFilterRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
 
 
 @Tag(name = "Branch", description = "대리점 조회 API")
@@ -27,5 +29,24 @@ public interface BranchTaxApi {
     SuccessResponse<BranchTaxFilterResponseList> findBranchTaxByFilters(
             @Parameter(description = "대리점 세금 계산서 필터 조건")
             @ModelAttribute BranchTaxFilterRequest request
+    );
+
+    @Operation(
+            summary = "대리점 세금 계산서 상세 조회",
+            description = "대리점 세금 계산서 상세 조회"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "대리점 세금계산서 상세 조회가 성공적으로 완료되었습니다."
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인한 사용자와 세금계산서의 대리점이 다릅니다."
+            )
+    })
+    SuccessResponse<BranchTaxDetailResponse> findBranchTaxDetail(
+            @Parameter(description = "세금계산서 ID")
+            @RequestParam Long taxId
     );
 }

--- a/src/main/java/com/seoulmilk/be/taxvalidation/dto/request/BranchTaxFilterRequest.java
+++ b/src/main/java/com/seoulmilk/be/taxvalidation/dto/request/BranchTaxFilterRequest.java
@@ -1,0 +1,26 @@
+package com.seoulmilk.be.taxvalidation.dto.request;
+
+import com.seoulmilk.be.tax.domain.type.PayStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BranchTaxFilterRequest {
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    @Schema(defaultValue = "NORMAL")
+    private String resultType;
+    private PayStatus payStatus;
+
+    @Builder.Default
+    private int page = 1;
+
+    @Builder.Default
+    private int size = 8;
+}

--- a/src/main/java/com/seoulmilk/be/taxvalidation/exception/TaxValidationException.java
+++ b/src/main/java/com/seoulmilk/be/taxvalidation/exception/TaxValidationException.java
@@ -7,5 +7,5 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class TaxValidationException extends RuntimeException {
-    private final ErrorCode code;
+    private final ErrorCode errorCode;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #21 

## 📝작업 내용
> 대리점 세금계산서 전체 조회
> 대리점 세금계산서 단일 조회

### 스크린샷 (선택)
<img width="1224" alt="스크린샷 2025-03-07 오전 6 12 18" src="https://github.com/user-attachments/assets/c6fda22c-efbc-4864-95f1-78c541caec8c" />
<img width="1214" alt="스크린샷 2025-03-07 오전 6 11 44" src="https://github.com/user-attachments/assets/5ddfe0fa-d95f-4891-b52b-f50780a6dfff" />

## 💬리뷰 요구사항(선택)
> repository와 service 에서 사업자 등록 번호의 ' - ' 를 제거합니다. 한 번씩 사용하는데 상수로 만들지, enum으로 만들지 그대로 사용할지 고민이 있습니다.
> `@RequestMapping("/tax-invoices/branch")` 에서 branches로 하는게 나을까요?