### PR TITLE
Refactor: (#52) 세금계산서 검증 대기 시간 변경

### DIFF
--- a/src/main/java/com/seoulmilk/be/taxvalidation/application/TaxValidationService.java
+++ b/src/main/java/com/seoulmilk/be/taxvalidation/application/TaxValidationService.java
@@ -30,8 +30,12 @@ import static com.seoulmilk.be.tax.exception.errorcode.NtsTaxErrorCode.NTS_TAX_N
 @RequiredArgsConstructor
 public class TaxValidationService {
     private static final String IS_VALIDATED = "1";
-    private static final Long REQUEST_TERM = 1_000L;
-    private static final Long VALIDATING_TERM = 10_200L;
+
+    @Value("${api.codef.request-term}")
+    private Long requestTerm;
+
+    @Value("${api.codef.validating-term}")
+    private Long validatingTerm;
 
     @Value("${api.codef.url}")
     private String productUrl;
@@ -60,7 +64,7 @@ public class TaxValidationService {
                     .build();
 
             thread.start();
-            sleepThread(1, REQUEST_TERM);
+            sleepThread(1, requestTerm);
         }
     }
 
@@ -68,7 +72,7 @@ public class TaxValidationService {
         User user = authService.getLoginUser();
 
         CodefRequestThreadManager.notifyUserThread(user.getCodefId());
-        sleepThread(requests.size(), VALIDATING_TERM);
+        sleepThread(requests.size(), validatingTerm);
         codefCacheService.removeTwoWayInfo(user.getCodefId());
 
         return findTaxIsNormal(getTaxes(requests));

--- a/src/main/java/com/seoulmilk/be/taxvalidation/application/thread/CodefRequestThread.java
+++ b/src/main/java/com/seoulmilk/be/taxvalidation/application/thread/CodefRequestThread.java
@@ -66,6 +66,7 @@ public class CodefRequestThread extends Thread {
                 codefRequest.user(), codefRequest.ntsTax(), codefRequest.loginTypeLevel());
         try {
             response = codefRequest.easyCodef().requestProduct(productUrl, EasyCodefServiceType.DEMO, body);
+            log.info("after taxId: {}, response: {}", codefRequest.ntsTax().getId(), response);
         } catch (UnsupportedEncodingException | InterruptedException | JsonProcessingException e) {
             throw new TaxValidationException(CODEF_API_ERROR);
         }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #52 

## 📝작업 내용
> 세금계산서 검증 대기 시간 배포 서버에 맞춰서 늘렸습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>